### PR TITLE
Use versionName from APK as extension version

### DIFF
--- a/chromeos-apk.js
+++ b/chromeos-apk.js
@@ -87,6 +87,7 @@ module.exports = function () {
         var messages = JSON.parse(fs.readFileSync(path.join(templatePath, '_locales', 'en', 'messages.json')));
         manifest.arc_metadata.name = packageName;
         manifest.arc_metadata.packageName = packageName;
+        manifest.version = data.versionName;
 
         if (program.name)
           messages.extName.message = program.name;


### PR DESCRIPTION
As cool as version "1337" is, it is possible to grab it from APK's AndroidManifest file. 

![version_cap](https://cloud.githubusercontent.com/assets/637374/4415464/a5f65a12-452b-11e4-998c-1099b075b5ac.PNG)
