### PR TITLE
Limit version to four integers

### DIFF
--- a/chromeos-apk.js
+++ b/chromeos-apk.js
@@ -87,7 +87,7 @@ module.exports = function () {
         var messages = JSON.parse(fs.readFileSync(path.join(templatePath, '_locales', 'en', 'messages.json')));
         manifest.arc_metadata.name = packageName;
         manifest.arc_metadata.packageName = packageName;
-        manifest.version = data.versionName || '1337';
+        manifest.version = data.versionName.split('.', 4).join('.') || '1337';
 
         if (program.name) {
           messages.extName.message = program.name;


### PR DESCRIPTION
Quick, and most likely nasty, fix to limit version number that is being copied from apk to four integers only. 
Tested with short version such as "3.2.4" and long version like "4.3.124.52.551" 
