### PR TITLE
Show help when are no arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 script:
   - cd .. && npm link chromeos-apk
   - wget https://github.com/uberspot/2048-android/archive/v1.91.zip && unzip v1.91.zip
+  - chromeos-apk # show help
   - chromeos-apk 2048-android-1.91/2048.apk -a -t
   - stat com.uberspot.a2048.android/vendor/chromium/crx/custom-android-release-1400197.apk
   - rm -rf com.uberspot.a2048.android

--- a/chromeos-apk.js
+++ b/chromeos-apk.js
@@ -24,6 +24,11 @@ module.exports = function (callback) {
     .usage('<path_to_apk_file ...>')
     .parse(process.argv);
 
+  if (process.argv.length == 2) {
+    program.outputHelp();
+    process.exit(0);
+  }
+
   var apk = program.args[0];
   callback = callback || success;
 


### PR DESCRIPTION
Before

https://travis-ci.org/ichigotake/chromeos-apk/builds/47321197

```
$ ./chromeos-apk 

/Users/ichigotake/Development/ichigotake/chromeos-apk/chromeos-apk.js:31
    throw new Error('Please provide a path to an APK file...');
          ^
Error: Please provide a path to an APK file...
    at module.exports (/Users/ichigotake/Development/ichigotake/chromeos-apk/chromeos-apk.js:31:11)
    at Object.<anonymous> (/Users/ichigotake/Development/ichigotake/chromeos-apk/chromeos-apk:3:29)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

After

https://travis-ci.org/ichigotake/chromeos-apk/builds/47321006

```
$ ./chromeos-apk 

  Usage: chromeos-apk <path_to_apk_file ...>

  Options:

    -h, --help          output usage information
    -V, --version       output the version number
    -t, --tablet        Create a tablet version
    -s, --scale         Enable application window scaling
    -n, --name [value]  Extension display name
```

