### PR TITLE
Fix issue #111

### DIFF
--- a/chromeos-apk.js
+++ b/chromeos-apk.js
@@ -20,7 +20,7 @@ module.exports = function (callback) {
     .version('4.0.2')
     .option('-t, --tablet', 'Create a tablet version')
     .option('-s, --scale', 'Enable application window scaling')
-    .option('-n, --name [value]', 'Extension display name')
+    .option('-n, --ext-name [value]', 'Extension display name')
     .usage('<path_to_apk_file ...>')
     .parse(process.argv);
 
@@ -89,8 +89,8 @@ module.exports = function (callback) {
         manifest.arc_metadata.packageName = packageName;
         manifest.version = '1337';
 
-        if (program.name) {
-          messages.extName.message = program.name;
+        if (program.extName) {
+          messages.extName.message = program.extName;
         } else if (packageName) {
           messages.extName.message = packageName;
         } else {


### PR DESCRIPTION
**`program.name` is** already **a function** (or should I say that `name` is a method of the `program` object?), then it **can't be** used as **a variable**.
(**`program.name()`** outputs **`chromeos-apk`** in this case, for the sake of completeness.)
So, using **`commander`**, if you set the long option name to **`--ext-name`**, it gives you the property **`extName`** of the object `program` (that is not taken). (If I am right with the OOP lingo.)