### PR TITLE
Fix plugin name detection

### DIFF
--- a/chromeos-apk.js
+++ b/chromeos-apk.js
@@ -90,7 +90,7 @@ module.exports = function (callback) {
         manifest.arc_metadata.packageName = packageName;
         manifest.version = '1337';
 
-        if (program.extName) {
+        if (program.extName && typeof program.name !== 'function') {
           messages.extName.message = program.extName;
         } else if (packageName) {
           messages.extName.message = packageName;


### PR DESCRIPTION
If -n option id not defined, program.name is function that returns name of chromeos-apk program itself, but converting function to JSON will return nothing, and "message" element of "extName" in messages.json will be skipped, that will produce an error at chrome plugin install step.